### PR TITLE
Add Portuguese-Brazil translation

### DIFF
--- a/language.list
+++ b/language.list
@@ -5,3 +5,4 @@ jpn => 日本語
 rus => Pyccĸий
 spa => Español
 pol => Polish
+bra => Português-Brasil

--- a/pt-br/lang.ini
+++ b/pt-br/lang.ini
@@ -1,0 +1,336 @@
+﻿# Arquivo de linguagem compatível com os identificadores do Minecraft: Pocket Edition
+#
+# A mensagem não precisa estar aqui para ser mostrada corretamente no cliente.
+# Somente as mensagens mostradas no Nukkit devem estar aqui
+# Usando o sistema de linguagens do PocketMine-MP
+#
+# Traduzido pelo MrPowerGamerBR (mrpowergamerbr.com)
+
+language.name=Português
+language.selected=Selecionado {%0} ({%1}) como a linguagem base
+
+multiplayer.player.joined={%0} entrou no jogo
+multiplayer.player.left={%0} saiu do jogo
+
+chat.type.text=<{%0}> {%1}
+chat.type.emote=* {%0} {%1}
+chat.type.announcement=[{%0}] {%1}
+chat.type.admin=[{%0}: {%1}]
+chat.type.achievement={%0} adquiriu a conquista {%1}
+
+disconnectionScreen.outdatedClient=Cliente desatualizado!
+disconnectionScreen.outdatedServer=Servidor desatualizado!
+disconnectionScreen.serverFull=O servidor está cheio!
+disconnectionScreen.noReason=Você foi desconectado
+disconnectionScreen.invalidSkin=Skin inválida!
+disconnectionScreen.invalidName=Nome inválido!
+
+death.fell.accident.generic={%0} caiu de um lugar alto
+death.attack.inFire={%0} pegou fogo
+death.attack.onFire={%0} queimou até a morte
+death.attack.lava={%0} tentou nadar na lava
+death.attack.inWall={%0} sufocou-se em uma parede
+death.attack.drown={%0} morreu afogado(a)
+death.attack.cactus={%0} foi espetado(a) até a morte
+death.attack.generic={%0} morreu
+death.attack.explosion={%0} explodiu
+death.attack.explosion.player={%0} foi explodido(a) por {%1}
+death.attack.magic={%0} foi morto(a) por magia
+death.attack.wither={%0} apodreceu
+death.attack.mob={%0} foi morto(a) por {%1}
+death.attack.player={%0} foi morto(a) por {%1}
+death.attack.player.item={%0} foi morto(a) por {%1} usando {%2}
+death.attack.arrow={%0} foi atingido(a) por {%1}
+death.attack.arrow.item={%0} foi atingido(a) por {%1} usando {%2}
+death.attack.fall={%0} caiu no chão com muita força
+death.attack.outOfWorld={%0} caiu para fora do mundo
+
+gameMode.survival=Modo Sobrevivência
+gameMode.creative=Modo Criativo
+gameMode.adventure=Modo Aventura
+gameMode.spectator=Modo Espectador
+gameMode.changed=Seu modo de jogo foi atualizado
+
+potion.moveSpeed=Velocidade
+potion.moveSlowdown=Lentidão
+potion.digSpeed=Pressa
+potion.digSlowDown=Cansaço
+potion.damageBoost=Força
+potion.heal=Vida Instantânea
+potion.harm=Dano Instantâneo
+potion.jump=Super Pulo
+potion.confusion=Náusea
+potion.regeneration=Regeneração
+potion.resistance=Resistência
+potion.fireResistance=Resistência ao Fogo
+potion.waterBreathing=Respiração Aquática
+potion.invisibility=Invisibilidade
+potion.blindness=Cegueira
+potion.nightVision=Visão Noturna
+potion.hunger=Fome
+potion.weakness=Fraqueza
+potion.poison=Veneno
+potion.wither=Wither
+potion.healthBoost=Vida Extra
+potion.absorption=Absorção
+potion.saturation=Saturação
+
+commands.generic.exception=Um erro ocorreu ao tentar realizar este comando
+commands.generic.permission=Você não tem permissão para usar este comando
+commands.generic.ingame=Você só pode usar este comando como um player
+commands.generic.notFound=Comando desconhecido. Tente /help para uma lista de comandos
+commands.generic.player.notFound=Esse(a) jogador(a) não pôde ser encontrado(a)
+commands.generic.usage=Uso: {%0}
+
+commands.time.added=Adicionado {%0} ao tempo
+commands.time.set=Tempo mudado para {%0}
+commands.time.query=O tempo é {%0}
+
+commands.me.usage=/me <ação ...>
+
+commands.give.item.notFound=Não há nenhum item com o nome: {%0}
+commands.give.success=Dado {%0} * {%1} para {%2}
+commands.give.tagError=Análise da tag de dados falhou: {%0}
+
+commands.effect.usage=/effect <jogador> <efeito> [segundos] [amplificador] [esconderPartículas] OU /effect <jogador> clear
+commands.effect.notFound=Não há nenhum efeito de monstro com o ID {%0}
+commands.effect.success=Dado {%0} (ID {%1}) * {%2} para {%3} por {%4} segundos
+commands.effect.success.removed=Retirado {%0} de {%1}
+commands.effect.success.removed.all=Todos os efeitos de {%0} foram removidos
+commands.effect.failure.notActive=Não foi possível retirar {%0} de {%1} pois este não possui o efeito
+commands.effect.failure.notActive.all=Nenhum efeito pôde ser removido de {%0} já que ele(a) não tem nenhum
+
+commands.enchant.noItem=O alvo não está segurando um item
+commands.enchant.notFound=Não há um encantamento com o ID {%0}
+commands.enchant.success=Encantado com sucesso
+commands.enchant.usage=/enchant <jogador> <ID do encantamento> [nível]
+
+commands.particle.success=Reproduzindo efeito {%0} por {%1} vezes
+commands.particle.notFound=Nome do efeito desconhecido {%0}
+
+commands.players.usage=/list
+commands.players.list=Existem {%0}/{%1} jogadores(as) online:
+
+commands.kill.successful=Eliminado(a) {%0}
+
+commands.banlist.ips=Existem {%0} endereços de IP banidos no total:
+commands.banlist.players=Existem {%0} jogadores(as) banidos(as) no total:
+commands.banlist.usage=/banlist [ips|players]
+
+commands.defaultgamemode.usage=/defaultgamemode <modo>
+commands.defaultgamemode.success=O modo de jogo padrão do mundo agora é {%0}
+
+commands.op.success={%0} virou operador(a)
+commands.op.usage=/op <jogador>
+
+commands.deop.success={%0} não é mais operador(a)
+commands.deop.usage=/deop <jogador>
+
+commands.say.usage=/say <mensagem ...>
+
+commands.seed.usage=/seed
+commands.seed.success=Seed: {%0}
+
+commands.ban.success={%0} foi banido(a)
+commands.ban.usage=/ban <nome> [razão ...]
+
+commands.unban.success={%0} foi desbanido(a)
+commands.unban.usage=/pardon <nome>
+
+commands.banip.invalid=Você digitou um IP inválido ou um(a) jogador(a) que não está online.
+commands.banip.offline.invalid=Não existe este IP na data dos players ou o IP é inválido
+commands.banip.success=Endereço IP banido {%0}
+commands.banip.success.players=Endereço IP banido {%0} pertencente a {%1}
+commands.banip.usage=/ban-ip <address|nome> [razão ...]
+
+commands.unbanip.invalid=Você digitou um IP inválido
+commands.unbanip.success=IP desbanido: {%0}
+commands.unbanip.usage=/pardon-ip <ip>
+
+commands.save.usage=/save-all
+commands.save-on.usage=/save-on
+commands.save-off.usage=/save-off
+commands.save.enabled=Salvamento automático ligado
+commands.save.disabled=Salvamento automático desligado
+commands.save.start=Salvando...
+commands.save.success=Mundo salvo
+
+commands.stop.usage=/stop
+commands.stop.start=Parando o servidor
+
+commands.kick.success={%0} foi expulso(a) do jogo
+commands.kick.success.reason={%0} foi expulso(a) do jogo. Motivo: '{%1}'
+commands.kick.usage=/kick <jogador> [motivo ...]
+
+commands.tp.success={%0} teletransportado(a) para {%1}
+commands.tp.success.coordinates=Teletransportado(a) {%0} para {%1}, {%2}, {%3}
+commands.tp.usage=/tp [jogador alvo] <jogador de destino> OU /tp [jogador alvo] <x> <y> <z> [<rot-x> <rot-y>]
+
+commands.whitelist.list=Existem {%0} (de {%1} vistos) jogadores(as) na whitelist:
+commands.whitelist.enabled=Whitelist ligada
+commands.whitelist.disabled=Whitelist desligada
+commands.whitelist.reloaded=Whitelist recarregada
+commands.whitelist.add.success={%0} foi adicionado(a) à whitelist
+commands.whitelist.add.usage=/whitelist add <jogador>
+commands.whitelist.remove.success={%0} foi removido(a) da whitelist
+commands.whitelist.remove.usage=/whitelist remove <jogador>
+commands.whitelist.usage=/whitelist <on|off|list|add|remove|reload>
+
+commands.gamemode.success.self=Mudado o próprio modo de jogo para {%0}
+commands.gamemode.success.other=Mudado o modo de jogo de {%0} para {%1}
+commands.gamemode.usage=/gamemode <modo> [jogador]
+
+commands.help.header=--- Mostrando página {%0} de {%1} (/help <página>) ---
+commands.help.usage=/help [página|nome do comando]
+
+commands.message.usage=/tell <jogador> <mensagem privada ...>
+commands.message.sameTarget=Você não pode enviar uma mensagem privada para si mesmo!
+
+commands.difficulty.usage=/difficulty <nova dificuldade>
+commands.difficulty.success=Dificuldade do jogo modificada para %s
+
+commands.spawnpoint.usage=/spawnpoint [jogador] [<x> <y> <z>]
+commands.spawnpoint.success=Local de renascimento de {%0} definido para ({%1}, {%2}, {%3})
+
+commands.setworldspawn.usage=/setworldspawn [<x> <y> <z>]
+commands.setworldspawn.success=Ponto de renascimento do mundo definido para ({%0}, {%1}, {%2})
+
+commands.weather.clear=Mudando para tempo limpo
+commands.weather.rain=Mudando para tempo chuvoso
+commands.weather.thunder=Mudando para chuva e trovões
+commands.weather.usage=/weather <clear|rain|thunder> [duração em segundos]
+
+
+# -------------------- Nukkit language files, only for console --------------------
+
+nukkit.data.playerNotFound=Data não encontrada do player "{%0}", criando novo perfil
+nukkit.data.playerCorrupted=Data corrompida do player "{%0}" encontrada, criando novo perfil
+nukkit.data.playerOld=Data antiga do player "{%0}" encontrada, atualizando perfil
+nukkit.data.saveError=Não foi possível salvar o player "{%0}": {%1}
+
+nukkit.level.notFound=Mundo "{%0}" não encontrado
+nukkit.level.loadError=Não foi possível carregar o mundo "{%0}": {%1}
+nukkit.level.generationError=Não foi possível gerar o mundo "{%0}": {%1}
+nukkit.level.tickError=Não foi possível fazer tick no mundo "{%0}": {%1}
+nukkit.level.chunkUnloadError=Erro ao descarregar o chunk: {%0}
+nukkit.level.backgroundGeneration=Spawn do terreno para o nível "{%0}" está sendo gerado em segundo plano
+nukkit.level.defaultError=Nenhum mundo padrão foi carregado
+nukkit.level.preparing=Preparando mundo "{%0}"
+nukkit.level.unloading=Descarregando mundo "{%0}"
+
+nukkit.server.start=Starting Minecraft: PE server version {%0}
+nukkit.server.networkError=[Rede] Interface finalizada em {%0} devido a {%1}
+nukkit.server.networkStart=Abrindo servidor em {%0}:{%1}
+nukkit.server.info=Este servidor está rodando {%0} versão {%1} "{%2}" (API {%3})
+nukkit.server.info.extended=Este servidor está rodando {%0} {%1} 「{%2}」 implementando versão da API {%3} para Minecraft: PE {%4} (versão do protocolo {%5})
+nukkit.server.license={%0} é distribuido com a licença LGPL
+nukkit.server.tickOverload=Não foi possível aguentar! Será que o servidor está sobrecarregado?
+nukkit.server.startFinished=Finalizado ({%0}s)! Para ajda, escreva "help" ou "?"
+nukkit.server.defaultGameMode=Modo de jogo padrão: {%0}
+nukkit.server.query.start=Iniciando listener de status GS4
+nukkit.server.query.info=Porta de query está ativada em {%0}
+nukkit.server.query.running=Query rodando em {%0}:{%1}
+
+nukkit.command.alias.illegal=Não foi possível registrar a alias {%0} porque ela contém caracteres ilegais.
+nukkit.command.alias.notFound=Não foi possível registrar a alias {%0} porque ela contém comandos que não existem: {%1}
+nukkit.command.exception=Exceção não tratada ao executando comando '{%0}' em {%1}: {%2}
+
+nukkit.command.plugins.description=Pega uma lista de plugins rodando no servidor
+nukkit.command.plugins.success=Plugins ({%0}): {%1}
+nukkit.command.plugins.usage=/plugins
+
+nukkit.command.reload.description=Recarrega a configuração do servidor e os plugins
+nukkit.command.reload.usage=/reload
+nukkit.command.reload.reloading=Recarregando server...
+nukkit.command.reload.reloaded=Recarregamento completo.
+
+nukkit.command.status.description=Mostra a performance do servidor.
+nukkit.command.status.usage=/status
+
+nukkit.command.gc.description=Ativa o garbage collection
+nukkit.command.gc.usage=/gc
+
+nukkit.command.timings.description=Grava timings para ver a performance do servidor.
+nukkit.command.timings.usage=/timings <reset|report|on|off|paste>
+nukkit.command.timings.enable=Ativando Timings & Resetado
+nukkit.command.timings.disable=Desativado Timings
+nukkit.command.timings.timingsDisabled=Por favor ative o timings usando /timings on
+nukkit.command.timings.reset=Timings resetados
+nukkit.command.timings.pasteError=Um erro ocorreu ao colar o relatório
+nukkit.command.timings.timingsUpload=Timings enviados para {%0}
+nukkit.command.timings.timingsRead=Você pode ver os resultados em {%0}
+nukkit.command.timings.timingsWrite=Timings escritos em {%0}
+
+nukkit.command.version.description=Pega a versão deste servidor incluindo todos os plugins em uso
+nukkit.command.version.usage=/version [nome do plugin]
+nukkit.command.version.noSuchPlugin=Este servidor não está usando nenhum plugin com este nome. Use /plugins para ver a lista de plugins.
+
+nukkit.command.give.description=Dá ao player especificado uma certa quantidade de itens
+nukkit.command.give.usage=/give <player> <item[:damage]> [quantidade] [tags...]
+
+nukkit.command.kill.description=Comite suicídio ou mata outros players
+nukkit.command.kill.usage=/kill [player]
+
+nukkit.command.particle.description=Adiciona partículas a um mundo
+nukkit.command.particle.usage=/particle <nome> <x> <y> <z> <xd> <yd> <zd> [quantidade] [data]
+
+nukkit.command.time.description=Altera o tempo em todos os mundos
+nukkit.command.time.usage=/time <alterar|adicionar> <value> OU /time <iniciar|parar|ver>
+
+nukkit.command.ban.player.description=Bloqueia o player especificado de usar este servidor
+nukkit.command.ban.ip.description=Bloqueia o IP especificado de usar este servidor
+nukkit.command.banlist.description=Ver todos os jogadores banidos deste servidor
+nukkit.command.defaultgamemode.description=Altera o modo de jogo padrão
+nukkit.command.deop.description=Remove o status de operador do player especificado
+nukkit.command.difficulty.description=Altera a dificuldade do jogo
+nukkit.command.enchant.description=Adiciona encantamento nos itens
+nukkit.command.effect.description=Adiciona/Remove efeitos nos players
+nukkit.command.gamemode.description=Altera o player para um tipo de jogo específico
+nukkit.command.help.description=Mostra o menu de ajuda
+nukkit.command.kick.description=Remove o player especificado do servidor
+nukkit.command.list.description=Mostra todos os players online
+nukkit.command.me.description=Performa a ação específica no chat
+nukkit.command.op.description=Dá o player especificado o status de operador
+nukkit.command.unban.player.description=Permite o jogador especificado usar este servidor
+nukkit.command.unban.ip.description=Permite o IP especificado usar este servidor
+nukkit.command.save.description=Salva o servidor para o disco
+nukkit.command.saveoff.description=Desativa o auto-salvamento do servidor
+nukkit.command.saveon.description=Ativa o auto-salvamento do servidor
+nukkit.command.say.description=Envia uma mensagem específica utilizando o enviador
+nukkit.command.seed.description=Mostra a seed do mundo
+nukkit.command.setworldspawn.description=Marca o spawn de um mundo. Se nenhuma coordenada está especificada, as coordenadas do player serão utilizadas.
+nukkit.command.spawnpoint.description=Marca o spawn de um player
+nukkit.command.stop.description=Fecha o servidor
+nukkit.command.tp.description=Teletransporta o player especificado (ou você) para outro player ou coordenadas
+nukkit.command.tell.description=Envia uma mensagem privada para o player
+nukkit.command.weather.description=Altera o tempo no mundo atual
+nukkit.command.whitelist.description=Administra a lista de players que podem usar este servidor
+
+nukkit.crash.create=Um erro irrecuperável ocorreu e o servidor travou. Criando um arquivo de erro
+nukkit.crash.error=Não foi possível criar o arquivo de erros: {%0}
+nukkit.crash.submit=Por favor envie o arquivo "{%0}" para o arquivo de erros e envie o link para a página de bug report. Dê o máximo de informações possíveis
+nukkit.crash.archive=O erro já foi automaticamente enviado para os arquivos de erros. Você pode ver no {%0} ou usando o ID #{%1}
+
+nukkit.debug.enable=Suporte a mundos LevelDB ativado
+
+nukkit.player.invalidMove={%0} moveu moved erradamente!
+nukkit.player.logIn={%0}[/{%1}:{%2}] entrou com o id de entidade {%3} em ({%4}, {%5}, {%6}, {%7})
+nukkit.player.logOut={%0}[/{%1}:{%2}] saiu devido a {%3}
+nukkit.player.invalidEntity={%0} tentou atacar uma entidade inválida
+
+nukkit.plugin.load=Carregando {%0}
+nukkit.plugin.enable=Ativando {%0}
+nukkit.plugin.disable=Desativando {%0}
+nukkit.plugin.restrictedName=Nome restrito
+nukkit.plugin.incompatibleAPI=Versão da API incompatível
+nukkit.plugin.unknownDependency=Dependência desconhecida
+nukkit.plugin.circularDependency=Dependência circular detectada
+nukkit.plugin.genericLoadError=Não foi possível carregar o plugin '{%0}'
+nukkit.plugin.spacesDiscouraged=Plugin '{%0}' usa espaço nos nome, isto é desencorajado
+nukkit.plugin.loadError=Não foi possível carregar o plugin '{%0}': {%1}
+nukkit.plugin.duplicateError=Não foi possível carregar o plugin '{%0}': plugin já existe
+nukkit.plugin.fileError=Não foi possível carregar '{%0}' na pasta '{%1}': {%2}
+nukkit.plugin.commandError=Não foi possível carregar o comando {%0} para o plugin {%1}
+nukkit.plugin.aliasError=Não foi possível carregar a alias {%0} para o plugin {%1}
+nukkit.plugin.deprecatedEvent=Plugin '{%0}' registrou um listener para '{%1}' no método '{%2}', mas o evento é obsoleto.
+nukkit.plugin.eventError="Não foi possível passar o evento '{%0}' para '{%1}': {%2} em {%3}

--- a/pt-br/nukkit.yml
+++ b/pt-br/nukkit.yml
@@ -1,0 +1,95 @@
+# Configurações avançadas para o Nukkit
+# Algumas destas Some of these configurações são seguras, outras podem destruir o seu servidor caso modificadas incorretamente
+# Novas configurações/padrões não irão aparecer neste arquivo ao atualizar.
+
+settings:
+ #Configuração de Multi-Linguagem
+ #Disponível: eng, chs, cht, jpn, rus, spa, pol, bra
+ language: "bra"
+ #Se é para enviar todos os textos traduzidos para a linguagem do servidor ou se é para o próprio dispositivo traduzir elas
+ force-language: false
+ shutdown-message: "Server closed"
+ #Permitir a listagem dos plugins via query
+ query-plugins: true
+ #Mostrar no console uma mensagem quando um plugin usa métodos obsoletos da API
+ deprecated-verbose: true
+ #Número de trabalhadores da AsyncTask
+ #Se marcado como auto, ele irá tentar detectar o número de núcleos (e no mínimo 4)
+ async-workers: auto
+
+network:
+ #Limite de lotes de packets, em bytes. Somente estes packets serão compactados
+ #Coloque 0 para compactar tudo, -1 para desativar.
+ batch-threshold: 256
+ #Nível de compressão usado pelo Zlib ao enviar packets compactados. Maior = mais uso na CPU, menos bandwidth utilizado.
+ compression-level: 7
+ #Usar AsyncTasks para a compressão. Adiciona metade de um/um tick de delay, menos uso na CPU na thread principal.
+ async-compression: false
+
+debug:
+ #Se maior de 1, as mensagens para debug irão ser mostradas no console
+ level: 1
+ #Ativa os comandos: /status /gc
+ commands: false
+
+level-settings:
+ #O formato padrão que os mundos irão usar ao serem criados
+ default-format: mcregion
+ #Mudar automaticamente o tick rate dos mundos para manter 20 ticks por segundo
+ auto-tick-rate: true
+ auto-tick-rate-limit: 20
+ #Altera a base do tick rate (1 = 20 ticks por segundos, 2 = 10 ticks por segundo, etc.)
+ base-tick-rate: 1
+ #Fazer tick em todos os players em todos os ticks mesmo quando as outras opções não permitem isto.
+ always-tick-players: false
+
+chunk-sending:
+ #Número de chunks enviados para os players por tick
+ per-tick: 4
+ #Número de chunks enviados em volta de cada player
+ max-chunks: 192
+ #Número de chunks que deverão ser enviados antes de spawnar o player
+ spawn-threshold: 56
+ #Salva uma cópia serializada do chunk na memória para enviar mais rapidamente.
+ #Útil em mundos normalmente estásticos que muitos players entram ao mesmo tempo
+ cache-chunks: false
+
+chunk-ticking:
+ #Máximo número de chunks processados em cada tick
+ per-tick: 40
+ #Raio de chunks em volta do player a ser tickados
+ tick-radius: 3
+ light-updates: false
+ clear-tick-list: false
+
+chunk-generation:
+ #Máximo número de chunks na fila de chunks para serem gerados
+ queue-size: 8
+ #Máximo número de chunks na fila de chunks para serem populados
+ population-queue-size: 8
+
+ticks-per:
+ animal-spawns: 400
+ monster-spawns: 1
+ autosave: 6000
+ cache-cleanup: 900
+
+spawn-limits:
+ #Mímaxo númerso destas entidades
+ monsters: 70
+ animals: 15
+ water-animals: 5
+ ambient: 15
+
+aliases:
+ #Aliases para comandos
+ #Exemplos:
+ #showtheversion: version
+ #savestop: [save-all, stop]
+
+worlds:
+ #Estas opções irão substituir o gerador definido no server.properties e permite carregar múltiplos mundos
+ #Exemplo:
+ #world:
+ # seed: 404
+ # generator: FLAT:2;7,59x1,3x3,2;1;decoration(treecount=80 grasscount=45)


### PR DESCRIPTION
I translated the "nukkit.yml" and the "lang.ini" to PT-BR.

I decided to keep the language name as "bra" instead of "por" because it is a PT-BR translation and not a PT-PT translation, but, if it needs to be changed to "por" (PocketMine: MP uses "por", but it is a PT-PT translation if I recall correctly) just ask that I will change it as soon as possible.

I added a very small credits on the "lang.ini" file, I can remove if it is needed, but I decided to add it on the "lang.ini" file instead of the "nukkit.yml" file to not affect user experience.

If any change needs to be made before merging, just ask that I will change. :+1: 
