### PR TITLE
Update Portuguese-Brazil

### DIFF
--- a/pt-br/lang.ini
+++ b/pt-br/lang.ini
@@ -218,14 +218,14 @@ nukkit.level.defaultError=Nenhum mundo padrão foi carregado
 nukkit.level.preparing=Preparando mundo "{%0}"
 nukkit.level.unloading=Descarregando mundo "{%0}"
 
-nukkit.server.start=Starting Minecraft: PE server version {%0}
+nukkit.server.start=Iniciando Servidor de Minecraft: PE, versão {%0}
 nukkit.server.networkError=[Rede] Interface finalizada em {%0} devido a {%1}
 nukkit.server.networkStart=Abrindo servidor em {%0}:{%1}
 nukkit.server.info=Este servidor está rodando {%0} versão {%1} "{%2}" (API {%3})
 nukkit.server.info.extended=Este servidor está rodando {%0} {%1} 「{%2}」 implementando versão da API {%3} para Minecraft: PE {%4} (versão do protocolo {%5})
 nukkit.server.license={%0} é distribuido com a licença LGPL
 nukkit.server.tickOverload=Não foi possível aguentar! Será que o servidor está sobrecarregado?
-nukkit.server.startFinished=Finalizado ({%0}s)! Para ajda, escreva "help" ou "?"
+nukkit.server.startFinished=Finalizado ({%0}s)! Para ver a ajuda, escreva "help" ou "?"
 nukkit.server.defaultGameMode=Modo de jogo padrão: {%0}
 nukkit.server.query.start=Iniciando listener de status GS4
 nukkit.server.query.info=Porta de query está ativada em {%0}
@@ -266,10 +266,10 @@ nukkit.command.version.usage=/version [nome do plugin]
 nukkit.command.version.noSuchPlugin=Este servidor não está usando nenhum plugin com este nome. Use /plugins para ver a lista de plugins.
 
 nukkit.command.give.description=Dá ao player especificado uma certa quantidade de itens
-nukkit.command.give.usage=/give <player> <item[:damage]> [quantidade] [tags...]
+nukkit.command.give.usage=/give <jogador> <item[:damage]> [quantidade] [tags...]
 
 nukkit.command.kill.description=Comite suicídio ou mata outros players
-nukkit.command.kill.usage=/kill [player]
+nukkit.command.kill.usage=/kill [jogador]
 
 nukkit.command.particle.description=Adiciona partículas a um mundo
 nukkit.command.particle.usage=/particle <nome> <x> <y> <z> <xd> <yd> <zd> [quantidade] [data]

--- a/pt-br/nukkit.yml
+++ b/pt-br/nukkit.yml
@@ -1,14 +1,14 @@
 # Configurações avançadas para o Nukkit
-# Algumas destas Some of these configurações são seguras, outras podem destruir o seu servidor caso modificadas incorretamente
+# Algumas destas configurações são seguras, outras podem destruir o seu servidor caso modificadas incorretamente
 # Novas configurações/padrões não irão aparecer neste arquivo ao atualizar.
 
 settings:
  #Configuração de Multi-Linguagem
- #Disponível: eng, chs, cht, jpn, rus, spa, pol, bra
- language: "bra"
+ #Disponível: eng, chs, cht, jpn, rus, spa, pol, pt-br
+ language: "pt-br"
  #Se é para enviar todos os textos traduzidos para a linguagem do servidor ou se é para o próprio dispositivo traduzir elas
  force-language: false
- shutdown-message: "Server closed"
+ shutdown-message: "Servidor fechado"
  #Permitir a listagem dos plugins via query
  query-plugins: true
  #Mostrar no console uma mensagem quando um plugin usa métodos obsoletos da API
@@ -75,7 +75,7 @@ ticks-per:
  cache-cleanup: 900
 
 spawn-limits:
- #Mímaxo númerso destas entidades
+ #Máximo número destas entidades
  monsters: 70
  animals: 15
  water-animals: 5


### PR DESCRIPTION
Fixes some misspellings, translates a string I forgot to translate, and some minor alterations on some messages to match the Mojang MCPE language (example: "player" > "jogador")
